### PR TITLE
Adding support for multiple architectures and ppc64le.

### DIFF
--- a/Dockerfile-ppc64le
+++ b/Dockerfile-ppc64le
@@ -1,0 +1,52 @@
+# Copyright 2015 Tigera, Inc
+# Copyright IBM Corp. 2017
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For details and docs - see https://github.com/phusion/baseimage-docker#getting_started
+
+FROM ppc64le/ubuntu:16.04
+
+RUN apt-get update && \
+	apt-get install -y python3-minimal
+
+CMD ["/sbin/my_init"]
+
+ENV HOME /root
+
+# Uncomment these lines and comment the section underneath to allow faster
+# rebuilds when making changes to the scripts.
+# The early scripts take a long time to run but change infrequently so
+# putting them on a their own lines allow developers to take advantage of
+# Docker's layer caching. The downside is much larger images.
+# ADD /image/buildconfig /build/buildconfig
+# ADD /image/my_init /build/my_init
+# ADD /image/confd /build/confd
+# ADD /image/install.sh /build/install.sh
+# RUN /build/install.sh
+# ADD /image/system_services.sh /build/system_services.sh
+# RUN	/build/system_services.sh
+# ADD /image/cleanup.sh /build/cleanup.sh
+# RUN	/build/cleanup.sh
+
+# Comment these lines out if using the developer-focused alternative instead.
+ADD /image /build
+RUN /build/install.sh && \
+	/build/system_services.sh && \
+	/build/cleanup.sh
+
+ADD /dist/confd /confd
+
+# Copy in our custom configuration files etc. We do this last to speed up
+# builds for developer, as it's thing they're most likely to change.
+COPY node_filesystem /

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,16 @@
+###############################################################################
+# The build architecture is select by setting the ARCH variable.
+# # For example: When building on ppc64le you could use ARCH=ppc64le make <....>.
+# # When ARCH is undefined it defaults to amd64.
+ARCH?=amd64
+ifeq ($(ARCH),amd64)
+	ARCHTAG?=
+endif
+
+ifeq ($(ARCH),ppc64le)
+	ARCHTAG:=-ppc64le
+endif
+
 .PHONEY: clean
 
 # These variables can be overridden by setting an environment variable.
@@ -10,7 +23,7 @@ CONFD_CONTAINER_NAME=${CONFD_REPO}:${CONFD_VER}
 default: clean calicorr.created
 
 calicorr.created: $(BUILD_FILES) dist/confd
-	docker build -t calico/routereflector .
+	docker build -t calico/routereflector$(ARCHTAG) -f Dockerfile$(ARCHTAG) .
 	touch calicorr.created
 
 clean:


### PR DESCRIPTION
The build architecture is select by setting the ARCH environment
variable. For example: When building on ppc64le you could use:

 ARCH=ppc64le make

When ARCH is undefined builds defaults to amd64.

Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
