### PR TITLE
Update install and cleanup scripts for ubuntu 16.04

### DIFF
--- a/image/cleanup.sh
+++ b/image/cleanup.sh
@@ -2,12 +2,6 @@
 set -e
 set -x
 
-# Remove extra packages using dpkg rather than apt-get - this prevents us from
-# deleting dependent packages that we still require.
-# - Remove any temporary packages installed in the install.sh script.
-echo "Removing extra packages"
-cat /tmp/add-apt.txt | xargs xargs dpkg -r --force-depends
-
 # Remove any other junk created during installation that is not required.
 apt-get clean
 rm -rf /build

--- a/image/install.sh
+++ b/image/install.sh
@@ -16,21 +16,17 @@ $minimal_apt_get_install apt-transport-https ca-certificates
 # Install add-apt-repository
 $minimal_apt_get_install software-properties-common
 
-# Find the list of packages just installed - these can be deleted later.
-grep -Fxvf  /tmp/base.txt <(dpkg -l | grep ^ii | sed 's_  _\t_g' | cut \
--f 2) >/tmp/add-apt.txt
-
 # Add new repos and update again
 LC_ALL=C.UTF-8 LANG=C.UTF-8 add-apt-repository -y ppa:cz.nic-labs/bird
 apt-get update
 
 # Install packages that should not be removed in the cleanup processing.
-# - bird and bird6
+# - bird and bird6 are both included with the bird package.
 # - packages required by felix
 # - pip (which includes various setuptools package discovery).
+
 $minimal_apt_get_install \
-        bird \
-        bird6
+	bird
 
 # Create the config directory for confd
 mkdir config


### PR DESCRIPTION
This patch allows install.sh and cleanup.sh to work
with Ubuntu 16.04.  The existing code used to clean-up some extra
stuff in the image will not work with ubuntu 16.04 as it removes 
some required python components.  I found this issue
when crating ppc64le images.

We should consider updating amd64 images to a later image base as well. 

Signed-off-by: David Wilder <wilder@us.ibm.com>


