### PR TITLE
Use Alpine instead of Ubuntu Trusty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2015 Tigera, Inc
+# Copyright (c) 2015-2017 Tigera, Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,28 +11,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# For details and docs - see https://github.com/phusion/baseimage-docker#getting_started
-
-FROM ubuntu:14.04
+FROM alpine
+LABEL maintainer "Neil Jerram <neil@tigera.io>"
 
 CMD ["/sbin/my_init"]
 
 ENV HOME /root
 
-# Uncomment these lines and comment the section underneath to allow faster
-# rebuilds when making changes to the scripts.
-# The early scripts take a long time to run but change infrequently so
-# putting them on a their own lines allow developers to take advantage of
-# Docker's layer caching. The downside is much larger images.
-#ADD /image/buildconfig /build/buildconfig
-#ADD /image/my_init /build/my_init
-#ADD /image/install.sh /build/install.sh
-#RUN /build/install.sh
-#ADD /image/system_services.sh /build/system_services.sh
-#RUN	/build/system_services.sh
-#ADD /image/cleanup.sh /build/cleanup.sh
-#RUN	/build/cleanup.sh
+RUN echo "ipv6" >> /etc/modules
+RUN echo "http://dl-1.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories; \
+    echo "http://dl-2.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories; \
+    echo "http://dl-3.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories; \
+    echo "http://dl-4.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories; \
+    echo "http://dl-5.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+RUN echo "http://dl-1.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories; \
+    echo "http://dl-2.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories; \
+    echo "http://dl-3.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories; \
+    echo "http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories; \
+    echo "http://dl-5.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+
+# Get prerequisite packages:
+# - bash, as it is needed (at least according to the #! line) by a
+#   lot of the following scripts and init infrastructure.
+# - shadow, for 'groupadd'.
+# - python3, for our 'my_init' wrapper.
+RUN apk add --no-cache bash shadow python3
 
 # Comment these lines out if using the developer-focused alternative instead.
 ADD /image /build

--- a/image/cleanup.sh
+++ b/image/cleanup.sh
@@ -2,14 +2,7 @@
 set -e
 set -x
 
-# Remove extra packages using dpkg rather than apt-get - this prevents us from
-# deleting dependent packages that we still require.
-# - Remove any temporary packages installed in the install.sh script.
-echo "Removing extra packages"
-cat /tmp/add-apt.txt | xargs xargs dpkg -r --force-depends
-
 # Remove any other junk created during installation that is not required.
-apt-get clean
 rm -rf /build
 rm -rf /tmp/* /var/tmp/*
 rm -rf /var/lib/apt/lists/*

--- a/image/install.sh
+++ b/image/install.sh
@@ -3,34 +3,8 @@ set -e
 source /build/buildconfig
 set -x
 
-# Upgrade all packages.
-apt-get update
-apt-get dist-upgrade -y --no-install-recommends
-
-# Determine the list of packages required for the base image.
-dpkg -l | grep ^ii | sed 's_  _\t_g' | cut -f 2 >/tmp/base.txt
-
-# Install HTTPS support for APT.
-$minimal_apt_get_install apt-transport-https ca-certificates
-
-# Install add-apt-repository
-$minimal_apt_get_install software-properties-common
-
-# Find the list of packages just installed - these can be deleted later.
-grep -Fxvf  /tmp/base.txt <(dpkg -l | grep ^ii | sed 's_  _\t_g' | cut \
--f 2) >/tmp/add-apt.txt
-
-# Add new repos and update again
-LC_ALL=C.UTF-8 LANG=C.UTF-8 add-apt-repository -y ppa:cz.nic-labs/bird
-apt-get update
-
-# Install packages that should not be removed in the cleanup processing.
-# - bird and bird6
-# - packages required by felix
-# - pip (which includes various setuptools package discovery).
-$minimal_apt_get_install \
-        bird \
-        bird6
+# Install bird and bird6
+apk add --no-cache bird bird6
 
 # Create the config directory for confd
 mkdir config

--- a/image/my_init
+++ b/image/my_init
@@ -221,7 +221,7 @@ def run_startup_files():
 
 def start_runit():
 	info("Booting runit daemon...")
-	pid = os.spawnl(os.P_NOWAIT, "/usr/bin/runsvdir", "/usr/bin/runsvdir",
+	pid = os.spawnl(os.P_NOWAIT, "/sbin/runsvdir", "/sbin/runsvdir",
 		"-P", "/etc/service")
 	info("Runit started as PID %d" % pid)
 	return pid
@@ -235,13 +235,13 @@ def wait_for_runit_or_interrupt(pid):
 
 def shutdown_runit_services():
 	debug("Begin shutting down runit services...")
-	os.system("/usr/bin/sv down /etc/service/*")
+	os.system("/sbin/sv down /etc/service/*")
 
 def wait_for_runit_services():
 	debug("Waiting for runit services to exit...")
 	done = False
 	while not done:
-		done = os.system("/usr/bin/sv status /etc/service/* | grep -q '^run:'") != 0
+		done = os.system("/sbin/sv status /etc/service/* | grep -q '^run:'") != 0
 		if not done:
 			time.sleep(0.1)
 
@@ -258,7 +258,7 @@ def main(args):
 
 	if not args.skip_startup_files:
 		run_startup_files()
-	
+
 	runit_exited = False
 	exit_code = None
 

--- a/image/system_services.sh
+++ b/image/system_services.sh
@@ -19,5 +19,4 @@ chmod 640 /etc/container_environment.sh /etc/container_environment.json
 ln -s /etc/container_environment.sh /etc/profile.d/
 
 ## Install runit.
-$minimal_apt_get_install runit
-
+apk add --no-cache runit


### PR DESCRIPTION
Alpine as a base should be more secure.  Also this gives us an image
size of 105MB, as against 292MB with Trusty.
