### PR TITLE
Bump confd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 LOCAL_IP_ENV?=$(shell ip route get 8.8.8.8 | head -1 | cut -d' ' -f8)
 
 CONFD_REPO?=calico/confd
-CONFD_VER?=v1.0.0-beta1-4-g4619952
+CONFD_VER?=v1.0.0-beta1-6-g47ad71a
 CONFD_CONTAINER_NAME=${CONFD_REPO}:${CONFD_VER}
 
 default: clean calicorr.created


### PR DESCRIPTION
## Description

Bump version of confd. This fixes should fix an error in KDD mode where RR was trying to run a list on host affinity blocks that was not supported. 

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
