### PR TITLE
[new feature] Adding support for OSPF propagation to border routers

### DIFF
--- a/node_filesystem/conf.d/bird.toml
+++ b/node_filesystem/conf.d/bird.toml
@@ -2,6 +2,6 @@
 src = "bird.cfg.template"
 dest = "/config/bird.cfg"
 prefix = "/calico/bgp/v1"
-keys = ["/rr_v4", "/global", "/host"]
+keys = ["/rr_v4", "/global", "/host", "/ospf_to_hosts"]
 check_cmd = "bird -p -c {{.src}}"
 reload_cmd = "pkill -HUP bird || true"

--- a/node_filesystem/templates/bird.cfg.template
+++ b/node_filesystem/templates/bird.cfg.template
@@ -20,6 +20,51 @@ template bgp bgp_template {
 
 {{$our_rr_key := printf "/rr_v4/%s" (getenv "IP")}}
 {{if ls $our_rr_key}}{{$our_rr_data := json (getv $our_rr_key)}}
+# ------------- RR-to-Border OSPF -------------
+{{if ls "/ospf_to_hosts"}}
+
+# import direct interfaces
+protocol direct {
+  interface -"cali*", -"docker*", "*";
+}
+
+# Synchronize them with the kernel
+protocol kernel kern1 {
+  export all;
+}
+
+# OSPF Export filters
+filter export_OSPF {
+  accept;
+}
+
+filter import_OSPF {
+  reject;
+}
+
+protocol ospf pods_ospf {
+  debug off;
+  export filter export_OSPF;
+  import filter import_OSPF;
+  area 0.0.0.0 {
+    interface "eth*" {
+      hello 10;
+      retransmit 5;
+      cost 10;
+      transmit delay 1;
+      dead count 4;
+      wait 40;
+      type ptp;
+      authentication none;
+      priority 0;
+      neighbors {
+        {{range gets "/ospf_to_hosts/*"}}{{$ohost := json .Value}}{{$ohost.ip}}{{if $ohost.eligible}} eligible{{end}};{{ end }}
+      };
+    };
+  };
+}
+
+{{ end }}
 # ------------- RR-to-RR full mesh -------------
 {{if ls "/rr_v4"}}
 {{range gets "/rr_v4/*"}}{{$data := json .Value}}{{$rr_ip := $data.ip}}


### PR DESCRIPTION
**New Feature :** Adding support for OSPF propagation to border routers

**The need :** 
In a lot of network infrastructures, OSPF is use for internal routing and BGP for external.
If we want Kubernetes pods to communicate with external equipment, we need to propagates pod's network to border routers.
For that, one of the possibilities is to let RR propagate with OSFP.

**Status :**
In production on our infrastructures since 1 years.

**How to : (with kukespray)**
=> kubespray/inventory/local/group_vars/all.yml
```
## Enable OSPF peering with list of routers
calico_ospf_peers:
  - ip: 172.18.188.1
    eligible: true
```

=> kubespray/roles/network_plugin/calico/rr/tasks/main.yml
```
- name: Calico-rr | Configure OSPF Export
  command: |-
    {{ bin_dir }}/etcdctl --peers={{ etcd_access_addresses }} \
    --cert-file {{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}.pem \
    --key-file {{ etcd_cert_dir }}/admin-{{ groups['etcd'][0] }}-key.pem \
    set /calico/bgp/v1/ospf_to_hosts/{{ item.ip }} '{{ item|to_json }}'
  delegate_to: "{{ groups['etcd'][0] }}"
  with_items: "{{ calico_ospf_peers }}"
  when: calico_ospf_peers|default([])|length > 0
```

- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
