### PR TITLE
Added support for s390x

### DIFF
--- a/Dockerfile-s390x
+++ b/Dockerfile-s390x
@@ -14,6 +14,11 @@
 
 # For details and docs - see https://github.com/phusion/baseimage-docker#getting_started
 
+# The Dockerfile-s390x is copied from routereflector/Dockerfile.
+# Modifications done includes:
+# 1) Base image has been changed from ubuntu:14.04 to s390x/ubuntu:16.04
+# 2) Added python3-minimal dependency
+
 FROM s390x/ubuntu:16.04
 
 RUN apt-get update && \

--- a/Dockerfile-s390x
+++ b/Dockerfile-s390x
@@ -1,0 +1,50 @@
+# Copyright 2015 Tigera, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For details and docs - see https://github.com/phusion/baseimage-docker#getting_started
+
+FROM s390x/ubuntu:16.04
+
+RUN apt-get update && \
+        apt-get install -y python3-minimal
+
+CMD ["/sbin/my_init"]
+
+ENV HOME /root
+
+# Uncomment these lines and comment the section underneath to allow faster
+# rebuilds when making changes to the scripts.
+# The early scripts take a long time to run but change infrequently so
+# putting them on a their own lines allow developers to take advantage of
+# Docker's layer caching. The downside is much larger images.
+#ADD /image/buildconfig /build/buildconfig
+#ADD /image/my_init /build/my_init
+#ADD /image/install.sh /build/install.sh
+#RUN /build/install.sh
+#ADD /image/system_services.sh /build/system_services.sh
+#RUN	/build/system_services.sh
+#ADD /image/cleanup.sh /build/cleanup.sh
+#RUN	/build/cleanup.sh
+
+# Comment these lines out if using the developer-focused alternative instead.
+ADD /image /build
+RUN /build/install.sh && \
+    /build/system_services.sh && \
+    /build/cleanup.sh
+
+ADD /dist/confd /confd
+
+# Copy in our custom configuration files etc. We do this last to speed up
+# builds for developer, as it's thing they're most likely to change.
+COPY node_filesystem /

--- a/Dockerfile-s390x
+++ b/Dockerfile-s390x
@@ -22,7 +22,7 @@
 FROM s390x/ubuntu:16.04
 
 RUN apt-get update && \
-        apt-get install -y python3-minimal
+        apt-get install -y python3-minimal && rm -rf /var/lib/apt/lists/*
 
 CMD ["/sbin/my_init"]
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ ifeq ($(ARCH),ppc64le)
 	ARCHTAG:=-ppc64le
 endif
 
+ifeq ($(ARCH),s390x)
+	ARCHTAG:=-s390x
+endif
+
 .PHONEY: clean
 
 # These variables can be overridden by setting an environment variable.


### PR DESCRIPTION
## Description
Added support for s390x. The routereflector changes w.r.t s390x has been tested and verified with calico v3.0.3 and v3.04 and all ST's are passing.
