### PR TITLE
Replicate all semaphore activities in ci and cd targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,24 @@ endif
 
 default: clean image
 
+.PHONY: ci cd
+## Builds the code and runs all tests.
+ci: $(IMAGE_CREATED_BASE)
+
+## Deploys images to registry
+cd:
+ifndef CONFIRM
+	$(error CONFIRM is undefined - run using make <target> CONFIRM=true)
+endif
+ifndef BRANCH_NAME
+	$(error BRANCH_NAME is undefined - run using make <target> BRANCH_NAME=var or set an environment variable)
+endif
+	$(MAKE) tag-images push IMAGETAG=${BRANCH_NAME}
+	$(MAKE) tag-images push IMAGETAG=$(shell git describe --tags --dirty --always --long)
+
+
+
+
 # standard build target, but nothing to do
 build:
 


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR

Replicate the workflow from kube-controllers PR here:

* Create a `make ci` target that does everything in the various semaphore jobs except tag images and push to registries
* Create a `make cd` target that only tags images and pushes to registries

Should update Semaphore after merged.

As discussed with @caseydavenport @fasaxc @tomdee



## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
