### PR TITLE
Place control Sockets in a separate folder

### DIFF
--- a/node_filesystem/etc/service/bird/run
+++ b/node_filesystem/etc/service/bird/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec bird -R -s bird.ctl -d -c /config/bird.cfg
+exec bird -R -s /sockets/bird.ctl -d -c /config/bird.cfg

--- a/node_filesystem/etc/service/bird6/run
+++ b/node_filesystem/etc/service/bird6/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec bird6 -R -s bird6.ctl -d -c /config/bird6.cfg
+exec bird6 -R -s /sockets/bird6.ctl -d -c /config/bird6.cfg

--- a/node_filesystem/sockets/README.md
+++ b/node_filesystem/sockets/README.md
@@ -1,0 +1,13 @@
+# Sockets
+
+bird and bird6 control sockets will go here in the running container.
+
+This allows easy interaction with third party tools (such as bird_exporter) that wish to interact with bird.
+
+## Example
+
+We would like to monitor bird and use the third party tool `bird_exporter` which connects to the bird sockets and allows `prometheus` to collect metrics.
+
+we *could* run `bird-exporter` in the same container but it probably not needed for all uses of calico/routereflector. This would also involve *building* bird-exporter for each target architecture and munging it into the relevant Dockerfile.
+
+Instead putting the control sockets in `/sockets` allows us options to share this folder with other things. For example in kubernetes we can mount an `emptyDir` volume onto that location and share the sockets accross 2 containers in the same pod. This allows us to run `bird-exporter` in it's own container as a sidecar in a kubernetes pod and is extensible to any other application.


### PR DESCRIPTION
Moving the location of the control sockets allows for this use case:

## Running a kubernetes sidecar container that interacts with routereflector

The control sockets for `bird` and `bird6` are opened in the `/sockets/` folder of the container. This allows us to share the sockets accross containers in the same kubernetes pod easily. One nice case would be to expose metrics using another open source project called [bird_exporter](https://github.com/czerwonk/bird_exporter`
)

We can do this ***fairly*** easily using a kubernetes an `emptyDir` kubernetes volume.

This example creates a deployment of a single pod containing two containers (`calico-reflector` and `calico-reflector-metrics`). They interact with each other using the controll sockets of `bird` and `bird6` by mounting a kubernetes `emptyVolume` on both container filesystems. (You'll need to provide an ETCD cluster and specify the values for *IP* and *ETCD_ENDPOINTS* for your environment)

The advantage of doing it this way means we can avoid bloat in the `routereflector` image for customers that don't need this functionality and make this reasonably easy to expand to different use cases.

```yaml
---
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: calico-bgp-reflector-1
  namespace: kube-system
  labels:
    calico-component: bgp-reflector
    k8s-app: calico-bgp-reflector-1
  annotations:
    scheduler.alpha.kubernetes.io/critical-pod: ''
spec:
  selector:
    matchLabels:
      calico-component: bgp-reflector
  replicas: 1
  strategy:
    type: Recreate
  template:
    metadata:
      name: calico-bgp-reflector-1
      namespace: kube-system
      labels:
        k8s-app: calico-bgp-reflector-1
        calico-component: bgp-reflector
    spec:
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchExpressions:
              - key: calico-component
                operator: In
                values:
                - bgp-reflector
            topologyKey: "kubernetes.io/hostname"
      hostNetwork: true
      volumes:
      - name: socketsshare
        emptyDir: {}
      containers:
      - name: calico-reflector
        volumeMounts:
        - name: socketsshare
          mountPath: /sockets
        image: calico/routereflector
        securityContext:
          privileged: true
        env:
          - name: IP
            value: "<YOURIP>"
          - name: ETCD_ENDPOINTS
            value: <"ETCD_ADDRESS>"
      - name: calico-reflector-metrics
        volumeMounts:
        - name: socketsshare
          mountPath: /sockets
        image: czerwonk/bird_exporter
        command: ["./bird_exporter"]
        args:
        - "-format.new=true"
        - "-bird.socket=/sockets/bird.ctl"
        - "-bird.socket6=/sockets/bird6.ctl"
...

---
apiVersion: v1
kind: Service
metadata:
  namespace: kube-system
  labels:
    k8s-app: calico-bgp-reflector-1
  name: calico-bgp-reflector-1
spec:
  ports:
  - port: 179
    protocol: TCP
    targetPort: 179
    name: bgp-tcp
  - port: 179
    protocol: UDP
    targetPort: 179
    name: bgp-udp
  - port: 9324
    protocol: TCP
    targetPort: 9234
    name: metrics
  selector:
    k8s-app: calico-bgp-reflector-1
  type: ClusterIP
...
```